### PR TITLE
Enable SGX stats.

### DIFF
--- a/graphene/openssl.manifest
+++ b/graphene/openssl.manifest
@@ -1,3 +1,3 @@
 sgx.allow_file_creation = 1
 sgx.enclave_size = 256M
-sgx.thread_num = 8
+#sgx.enable_stats = 1


### PR DESCRIPTION
- Enable SGX stats in manifest file to analyze openSSL speed test performance.
- Keep SGX stats commented by default.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>